### PR TITLE
Change leftover "system" to environment

### DIFF
--- a/pycona/active_algorithms/algorithm_core.py
+++ b/pycona/active_algorithms/algorithm_core.py
@@ -12,7 +12,7 @@ class AlgorithmCAInteractive(ABC):
 
     def __init__(self, ca_env: ActiveCAEnv = None):
         """
-        Initialize the AlgorithmCAInteractive with a constraint acquisition system.
+        Initialize the AlgorithmCAInteractive with a constraint acquisition environment.
 
         :param ca_env: A ca environment.
         """

--- a/pycona/active_algorithms/gquacq.py
+++ b/pycona/active_algorithms/gquacq.py
@@ -21,9 +21,9 @@ class GQuAcq(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None, qg_max=10):
         """
-        Initialize the PQuAcq algorithm with an optional constraint acquisition system.
+        Initialize the PQuAcq algorithm with an optional constraint acquisition environment.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         : param GQmax: maximum number of generalization queries
         """
         super().__init__(ca_env)

--- a/pycona/active_algorithms/growacq.py
+++ b/pycona/active_algorithms/growacq.py
@@ -17,9 +17,9 @@ class GrowAcq(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None, inner_algorithm: AlgorithmCAInteractive = None):
         """
-        Initialize the GrowAcq algorithm with an optional constraint acquisition system and inner algorithm.
+        Initialize the GrowAcq algorithm with an optional constraint acquisition environment and inner algorithm.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         :param inner_algorithm: An instance of ICA_Algorithm to be used as the inner algorithm, default is MQuAcq2.
         """
         env = ca_env if ca_env is not None else ProbaActiveCAEnv()

--- a/pycona/active_algorithms/mquacq.py
+++ b/pycona/active_algorithms/mquacq.py
@@ -15,9 +15,9 @@ class MQuAcq(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None):
         """
-        Initialize the MQuAcq algorithm with an optional constraint acquisition system.
+        Initialize the MQuAcq algorithm with an optional constraint acquisition environment.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         """
         super().__init__(ca_env)
 

--- a/pycona/active_algorithms/mquacq2.py
+++ b/pycona/active_algorithms/mquacq2.py
@@ -17,10 +17,10 @@ class MQuAcq2(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None, *, perform_analyzeAndLearn: bool = True, cliques_cutoff=1):
         """
-        Initialize the MQuAcq2 algorithm with an optional constraint acquisition system,
+        Initialize the MQuAcq2 algorithm with an optional constraint acquisition environment,
         a flag to perform analyze and learn, and a cliques cutoff value.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         :param perform_analyzeAndLearn: A boolean flag to perform analyze and learn, default is True.
         :param cliques_cutoff: A cutoff value for cliques, default is 1.
         """

--- a/pycona/active_algorithms/pquacq.py
+++ b/pycona/active_algorithms/pquacq.py
@@ -19,9 +19,9 @@ class PQuAcq(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None):
         """
-        Initialize the PQuAcq algorithm with an optional constraint acquisition system.
+        Initialize the PQuAcq algorithm with an optional constraint acquisition environment.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         """
         super().__init__(ca_env)
 

--- a/pycona/active_algorithms/quacq.py
+++ b/pycona/active_algorithms/quacq.py
@@ -15,9 +15,9 @@ class QuAcq(AlgorithmCAInteractive):
 
     def __init__(self, ca_env: ActiveCAEnv = None):
         """
-        Initialize the QuAcq algorithm with an optional constraint acquisition system.
+        Initialize the QuAcq algorithm with an optional constraint acquisition environment.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         """
         super().__init__(ca_env)
 

--- a/pycona/ca_environment/acive_ca_proba.py
+++ b/pycona/ca_environment/acive_ca_proba.py
@@ -8,8 +8,8 @@ from sklearn.tree import DecisionTreeClassifier
 
 class ProbaActiveCAEnv(ActiveCAEnv):
     """
-    Class interface for the prediction based interactive CA system, using predictions for the constraints.
-    Storing the necessary elements and providing functionality to update the state of the system as needed.
+    Class interface for the prediction based interactive CA environment, using predictions for the constraints.
+    Storing the necessary elements and providing functionality to update the state of the environment as needed.
     """
 
     def __init__(self, qgen: 'QGenBase' = None,

--- a/pycona/ca_environment/active_ca.py
+++ b/pycona/ca_environment/active_ca.py
@@ -8,8 +8,9 @@ from ..utils import get_kappa
 
 class ActiveCAEnv(CAEnv):
     """
-    Class interface for the interactive CA systems. Using all CA components (Algorithm, Query generation, FindScope,
-    FindC etc.), storing the necessary elements and providing functionality to update the state of the system as needed.
+    Class interface for the interactive CA environment. Using all CA components (Algorithm, Query generation, FindScope,
+    FindC etc.), storing the necessary elements and providing functionality to update the state of the ca environment
+     as needed.
     """
 
     def __init__(self, qgen: 'QGenBase' = None,

--- a/pycona/ca_environment/ca_env_core.py
+++ b/pycona/ca_environment/ca_env_core.py
@@ -9,7 +9,7 @@ class CAEnv(ABC):
 
     def __init__(self):
         """
-        Initialize the CA system.
+        Initialize the CA environment.
         """
         self._instance = None
         self.metrics = None
@@ -17,7 +17,7 @@ class CAEnv(ABC):
         self.converged = False
 
     def init_state(self, **kwargs):
-        """ Initialize the state of the CA system. """
+        """ Initialize the state of the CA environment. """
         self._converged = False
 
     @property
@@ -42,12 +42,12 @@ class CAEnv(ABC):
 
     @property
     def verbose(self):
-        """ Get the verbosity of the system """
+        """ Get the verbosity of the environment """
         return self._verbose
 
     @verbose.setter
     def verbose(self, verbose):
-        """ Set the verbosity of the system """
+        """ Set the verbosity of the environment """
         self._verbose = verbose
 
     @property

--- a/pycona/find_constraint/findc.py
+++ b/pycona/find_constraint/findc.py
@@ -14,15 +14,15 @@ class FindC(FindCBase):
     Bessiere, Christian, et al., "Learning constraints through partial queries", AIJ 2023
     """
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2, *, findc_obj=findc_obj_splithalf):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2, *, findc_obj=findc_obj_splithalf):
         """
         Initialize the FindC class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findc query generation.
         :param findc_obj: The function to use for findc objective, default is findc_obj_splithalf.
         """
-        super().__init__(ca_system, time_limit, findc_obj=findc_obj)
+        super().__init__(ca_env, time_limit, findc_obj=findc_obj)
 
     def run(self, scope):
         """

--- a/pycona/find_constraint/findc2.py
+++ b/pycona/find_constraint/findc2.py
@@ -16,15 +16,15 @@ class FindC2(FindCBase):
     """
     # TODO optimize to work better (probably only needs to make better the generate_find_query2)
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2, findscope=None):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2, findscope=None):
         """
         Initialize the FindC2 class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findc query generation.
         :param findscope: The function to find the scope.
         """
-        super().__init__(ca_system, time_limit)
+        super().__init__(ca_env, time_limit)
         self._findscope = findscope
 
     @property

--- a/pycona/find_constraint/findc_core.py
+++ b/pycona/find_constraint/findc_core.py
@@ -11,15 +11,15 @@ class FindCBase(ABC):
     Abstract class interface for FindC implementations.
     """
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2, *, findc_obj=findc_obj_splithalf):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2, *, findc_obj=findc_obj_splithalf):
         """
         Initialize the FindCBase class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findc query generation.
         :param findc_obj: The function to use for findc object, default is findc_obj_splithalf.
         """
-        self.ca = ca_system
+        self.ca = ca_env
         self._time_limit = time_limit
         self.obj = findc_obj
 
@@ -36,21 +36,21 @@ class FindCBase(ABC):
     @property
     def ca(self):
         """
-        Get the constraint acquisition system.
+        Get the constraint acquisition environment.
 
-        :return: The constraint acquisition system.
+        :return: The constraint acquisition environment.
         """
         return self._ca
 
     @ca.setter
-    def ca(self, ca_system: ActiveCAEnv = None):
+    def ca(self, ca_env: ActiveCAEnv = None):
         """
-        Set the constraint acquisition system.
+        Set the constraint acquisition environment.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         """
-        if ca_system is not None:
-            self._ca = ca_system
+        if ca_env is not None:
+            self._ca = ca_env
             if self._ca.findc != self:
                 self._ca.findc = self
 
@@ -131,7 +131,7 @@ class FindCBase(ABC):
         # So a solution was found, try to find a better one now
         s.solution_hint(Y, values)
 
-        objective = self.obj(sat, delta, ca_system=self.ca)
+        objective = self.obj(sat, delta, ca_env=self.ca)
         # Run with the objective
         s.maximize(objective)  # We want to try and do it like a dichotomic search
 

--- a/pycona/find_constraint/findc_obj.py
+++ b/pycona/find_constraint/findc_obj.py
@@ -14,19 +14,19 @@ def findc_obj_splithalf(sat, delta, **kwargs):
     """
     return abs(sat - round(len(delta) / 2))
 
-def findc_obj_proba(sat, delta, ca_system: ActiveCAEnv, **kwargs):
+def findc_obj_proba(sat, delta, ca_env: ActiveCAEnv, **kwargs):
     """
     Probability-based objective function for FindC.
 
     :param sat: The number of satisfied constraints.
     :param delta: The candidate constraints in the given scope.
-    :param ca_system: The constraint acquisition system.
+    :param ca_env: The constraint acquisition environment.
     :return: The objective value.
-    :raises Exception: If the ca_environment is not an instance of CASystemPredict.
+    :raises Exception: If the ca_environment is not an instance of ProbaActiveCAEnv.
     """
-    if not isinstance(ca_system, ProbaActiveCAEnv):
-        raise Exception('Probability based objective can only be used with CASystemPredict')
-    proba = {c: ca_system.bias_proba[c] for c in delta}
+    if not isinstance(ca_env, ProbaActiveCAEnv):
+        raise Exception('Probability based objective can only be used with ProbaActiveCAEnv')
+    proba = {c: ca_env.bias_proba[c] for c in delta}
 
     Y = get_scope(delta[0])
     Y = list(dict.fromkeys(Y))  # Remove duplicates

--- a/pycona/find_scope/findscope.py
+++ b/pycona/find_scope/findscope.py
@@ -9,14 +9,14 @@ class FindScope(FindScopeBase):
     Bessiere, Christian, et al., "Constraint acquisition via Partial Queries", IJCAI 2013.
     """
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2):
         """
         Initialize the FindScope class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findscope query generation.
         """
-        super().__init__(ca_system, time_limit)
+        super().__init__(ca_env, time_limit)
 
     def run(self, Y):
         """

--- a/pycona/find_scope/findscope2.py
+++ b/pycona/find_scope/findscope2.py
@@ -9,14 +9,14 @@ class FindScope2(FindScopeBase):
     Bessiere, Christian, et al., "Learning constraints through partial queries", AIJ 2023
     """
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2):
         """
         Initialize the FindScope2 class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findscope query generation.
         """
-        super().__init__(ca_system, time_limit)
+        super().__init__(ca_env, time_limit)
         self._kappaB = []
 
     def run(self, Y, kappa=None):

--- a/pycona/find_scope/findscope_core.py
+++ b/pycona/find_scope/findscope_core.py
@@ -9,15 +9,15 @@ class FindScopeBase(ABC):
     Abstract class interface for FindScope implementations
     """
 
-    def __init__(self, ca_system: ActiveCAEnv = None, time_limit=0.2, *, split_func=split_half):
+    def __init__(self, ca_env: ActiveCAEnv = None, time_limit=0.2, *, split_func=split_half):
         """
         Initialize the FindScopeBase class.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         :param time_limit: The time limit for findscope variable spliting.
         :param split_func: The function used to split the variables in findscope.
         """
-        self.ca = ca_system
+        self.ca = ca_env
         self._time_limit = time_limit
         self.split_func = split_func
 
@@ -44,21 +44,21 @@ class FindScopeBase(ABC):
     @property
     def ca(self):
         """
-        Get the constraint acquisition system.
+        Get the constraint acquisition environment.
 
-        :return: The constraint acquisition system.
+        :return: The constraint acquisition environment.
         """
         return self._ca
 
     @ca.setter
-    def ca(self, ca_system: ActiveCAEnv):
+    def ca(self, ca_env: ActiveCAEnv):
         """
-        Set the constraint acquisition system.
+        Set the constraint acquisition environment.
 
-        :param ca_system: The constraint acquisition system.
+        :param ca_env: The constraint acquisition environment.
         """
-        if ca_system is not None:
-            self._ca = ca_system
+        if ca_env is not None:
+            self._ca = ca_env
             if self._ca.find_scope != self:
                 self._ca.find_scope = self
 

--- a/pycona/query_generation/pqgen.py
+++ b/pycona/query_generation/pqgen.py
@@ -18,7 +18,7 @@ class PQGen(QGenBase):
         """
         Initialize the PQGen with the given parameters.
 
-        :param ca_env: The CA system.
+        :param ca_env: The CA environment.
         :param objective_function: The objective function for PQGen.
         :param time_limit: The time limit for query generation.
         :param blimit: The bias limit to start optimization.

--- a/pycona/query_generation/pqgen.py
+++ b/pycona/query_generation/pqgen.py
@@ -128,7 +128,7 @@ class PQGen(QGenBase):
         # So a solution was found, try to find a better one now
         s.solution_hint(lY, values)
         try:
-            objective = self.obj(B=B, ca_system=self.env)
+            objective = self.obj(B=B, ca_env=self.env)
         except:
             raise NotImplementedError(f"Objective given not implemented in PQGen: {self.obj} - Please report an issue")
 

--- a/pycona/query_generation/qgen.py
+++ b/pycona/query_generation/qgen.py
@@ -15,7 +15,7 @@ class QGen(QGenBase):
         """
         Initialize the QGen class.
 
-        :param ca_env: An instance of CASystem, default is None.
+        :param ca_env: An instance of ActiveCAEnv, default is None.
         :param time_limit: Time limit for the solver, default is 600 seconds.
         """
         super().__init__(ca_env, time_limit)

--- a/pycona/query_generation/qgen_core.py
+++ b/pycona/query_generation/qgen_core.py
@@ -9,9 +9,9 @@ class QGenBase(ABC):
 
     def __init__(self, ca_env: ActiveCAEnv = None, time_limit=2):
         """
-        Initialize the QGenBase with the given CA system and time limit.
+        Initialize the QGenBase with the given CA environment and time limit.
 
-        :param ca_env: The CA system used.
+        :param ca_env: The CA environment used.
         :param time_limit: Overall time limit.
         """
         self._env = ca_env

--- a/pycona/query_generation/qgen_obj.py
+++ b/pycona/query_generation/qgen_obj.py
@@ -25,24 +25,24 @@ def obj_min_viol(B, **kwargs):
     return sum([c for c in B])
 
 
-def obj_proba(B, ca_system: ActiveCAEnv, **kwargs):
+def obj_proba(B, ca_env: ActiveCAEnv, **kwargs):
     """
     Probability-based objective function.
 
     :param B: A list of constraints.
-    :param ca_system: An instance of CASystem.
+    :param ca_env: An instance of ActiveCAEnv.
     :return: The probability-based objective function.
-    :raises Exception: If ca_environment is not an instance of CASystemPredict.
+    :raises Exception: If ca_environment is not an instance of ProbaActiveCAEnv.
     """
-    if not isinstance(ca_system, ProbaActiveCAEnv):
-        raise Exception('Probability based objective can only be used with CASystemPredict')
+    if not isinstance(ca_env, ProbaActiveCAEnv):
+        raise Exception('Probability based objective can only be used with ProbaActiveCAEnv')
 
-    proba = {c: ca_system.bias_proba[c] for c in B}
+    proba = {c: ca_env.bias_proba[c] for c in B}
     Y = get_variables_from_constraints(B)
 
     O_c = [((1 / proba[c]) <= math.log2(len(Y))) for c in B]
     objective = sum(
-        [~c * (1 - len(ca_system.instance.language) * o_c) for
+        [~c * (1 - len(ca_env.instance.language) * o_c) for
          c, o_c in zip(B, O_c)])
 
     return objective


### PR DESCRIPTION
Original design had CASystem instead of CAEnvironment. After the change, several CASystem references had been left in the code (comments, etc). This PR cleans it