### PR TITLE
Growacq fixes on Bias construction

### DIFF
--- a/pycona/active_algorithms/gquacq.py
+++ b/pycona/active_algorithms/gquacq.py
@@ -66,6 +66,7 @@ class GQuAcq(AlgorithmCAInteractive):
                 if self.env.verbose >= 1:
                     print(f"\nLearned {self.env.metrics.cl} constraints in "
                           f"{self.env.metrics.membership_queries_count} queries.")
+                self.env.instance.bias = []
                 return self.env.instance
 
             self.env.metrics.increase_generation_time(gen_end - gen_start)

--- a/pycona/active_algorithms/gquacq.py
+++ b/pycona/active_algorithms/gquacq.py
@@ -48,7 +48,7 @@ class GQuAcq(AlgorithmCAInteractive):
         self.env.init_state(instance, oracle, verbose, metrics)
 
         if len(self.env.instance.bias) == 0:
-            self.env.instance.construct_bias()
+            self.env.instance.construct_bias(X)
 
         while True:
             if self.env.verbose > 0:

--- a/pycona/active_algorithms/growacq.py
+++ b/pycona/active_algorithms/growacq.py
@@ -57,7 +57,7 @@ class GrowAcq(AlgorithmCAInteractive):
             Y.append(x)
             # add the constraints involving x and other added variables
             if len(self.env.instance.bias) == 0:
-                self.env.instance.construct_bias_for_var(x, Y)
+                self.env.instance.construct_bias_for_vars(x, Y)
             if verbose >= 3:
                 print(f"Added variable {x} in GrowAcq")
                 print("size of B in growacq: ", len(self.env.instance.bias))

--- a/pycona/active_algorithms/mquacq.py
+++ b/pycona/active_algorithms/mquacq.py
@@ -39,7 +39,7 @@ class MQuAcq(AlgorithmCAInteractive):
         self.env.init_state(instance, oracle, verbose, metrics)
 
         if len(self.env.instance.bias) == 0:
-            self.env.instance.construct_bias()
+            self.env.instance.construct_bias(X)
 
         while True:
             if self.env.verbose >= 3:

--- a/pycona/active_algorithms/mquacq.py
+++ b/pycona/active_algorithms/mquacq.py
@@ -61,6 +61,7 @@ class MQuAcq(AlgorithmCAInteractive):
                 if self.env.verbose >= 1:
                     print(f"\nLearned {self.env.metrics.cl} constraints in "
                           f"{self.env.metrics.membership_queries_count} queries.")
+                self.env.instance.bias = []
                 return self.env.instance
 
             self.env.metrics.increase_generation_time(gen_end - gen_start)

--- a/pycona/active_algorithms/mquacq2.py
+++ b/pycona/active_algorithms/mquacq2.py
@@ -53,7 +53,7 @@ class MQuAcq2(AlgorithmCAInteractive):
         self.cl_neighbours = np.zeros((len(self.env.instance.X), len(self.env.instance.X)), dtype=bool)
 
         if len(self.env.instance.bias) == 0:
-            self.env.instance.construct_bias()
+            self.env.instance.construct_bias(X)
 
         while True:
             gen_start = time.time()

--- a/pycona/active_algorithms/mquacq2.py
+++ b/pycona/active_algorithms/mquacq2.py
@@ -67,6 +67,7 @@ class MQuAcq2(AlgorithmCAInteractive):
                 if self.env.verbose >= 1:
                     print(f"\nLearned {self.env.metrics.cl} constraints in "
                           f"{self.env.metrics.membership_queries_count} queries.")
+                self.env.instance.bias = []
                 return self.env.instance
 
             self.env.metrics.increase_generated_queries()

--- a/pycona/active_algorithms/pquacq.py
+++ b/pycona/active_algorithms/pquacq.py
@@ -61,6 +61,7 @@ class PQuAcq(AlgorithmCAInteractive):
                 if self.env.verbose >= 1:
                     print(f"\nLearned {self.env.metrics.cl} constraints in "
                           f"{self.env.metrics.membership_queries_count} queries.")
+                self.env.instance.bias = []
                 return self.env.instance
 
             self.env.metrics.increase_generation_time(gen_end - gen_start)

--- a/pycona/active_algorithms/pquacq.py
+++ b/pycona/active_algorithms/pquacq.py
@@ -43,7 +43,7 @@ class PQuAcq(AlgorithmCAInteractive):
         self.env.init_state(instance, oracle, verbose, metrics)
 
         if len(self.env.instance.bias) == 0:
-            self.env.instance.construct_bias()
+            self.env.instance.construct_bias(X)
 
         while True:
             if self.env.verbose > 0:

--- a/pycona/active_algorithms/quacq.py
+++ b/pycona/active_algorithms/quacq.py
@@ -39,7 +39,7 @@ class QuAcq(AlgorithmCAInteractive):
         self.env.init_state(instance, oracle, verbose, metrics)
 
         if len(self.env.instance.bias) == 0:
-            self.env.instance.construct_bias()
+            self.env.instance.construct_bias(X)
 
         while True:
             if self.env.verbose > 2:

--- a/pycona/active_algorithms/quacq.py
+++ b/pycona/active_algorithms/quacq.py
@@ -57,6 +57,7 @@ class QuAcq(AlgorithmCAInteractive):
                 if self.env.verbose >= 1:
                     print(f"\nLearned {self.env.metrics.cl} constraints in "
                           f"{self.env.metrics.membership_queries_count} queries.")
+                self.env.instance.bias = []
                 return self.env.instance
 
             self.env.metrics.increase_generation_time(gen_end - gen_start)


### PR DESCRIPTION
After some changes of previous PRs, the construction of Bias in GrowAcq is actually not optimal.

Inner algorithms were constructing the full bias in the first iteration directly, as the bias given by growacq was empty.

This is fixed, along with some more issues regarding how PQGen handled that case, of having a larger bias than the variables it considered, and how bias is constructed in problem instance.

Finally, here we also have a minor fix about emptying the bias after an inner algorithm finishes in growacq, in case redundant constraints remain there, so that it can continue to the rest of the problem.