### PR TITLE
Update benchmarks default values

### DIFF
--- a/pycona/benchmarks/exam_timetabling.py
+++ b/pycona/benchmarks/exam_timetabling.py
@@ -8,7 +8,7 @@ def day_of_exam(course, slots_per_day):
     return course // slots_per_day
 
 
-def construct_examtt_simple(nsemesters=9, courses_per_semester=6, slots_per_day=9, days_for_exams=14):
+def construct_examtt_simple(nsemesters=6, courses_per_semester=3, slots_per_day=3, days_for_exams=10):
     """
     :return: a ProblemInstance object, along with a constraint-based oracle
     """

--- a/pycona/benchmarks/job_shop_scheduling.py
+++ b/pycona/benchmarks/job_shop_scheduling.py
@@ -8,7 +8,7 @@ from ..answering_queries.constraint_oracle import ConstraintOracle
 from ..problem_instance import ProblemInstance, absvar
 
 
-def construct_job_shop_scheduling_problem(n_jobs, machines, horizon, seed=0):
+def construct_job_shop_scheduling_problem(n_jobs=10, machines=2, horizon=15, seed=0):
     """
     :return: a ProblemInstance object, along with a constraint-based oracle
     """

--- a/pycona/benchmarks/sudoku.py
+++ b/pycona/benchmarks/sudoku.py
@@ -4,7 +4,7 @@ from ..answering_queries.constraint_oracle import ConstraintOracle
 from ..problem_instance import ProblemInstance, absvar
 
 
-def construct_sudoku(block_size_row=3, block_size_col=3, grid_size=9):
+def construct_sudoku(block_size_row=2, block_size_col=2, grid_size=4):
     """
     :return: a ProblemInstance object, along with a constraint-based oracle
     """

--- a/pycona/benchmarks/sudoku.py
+++ b/pycona/benchmarks/sudoku.py
@@ -4,7 +4,7 @@ from ..answering_queries.constraint_oracle import ConstraintOracle
 from ..problem_instance import ProblemInstance, absvar
 
 
-def construct_sudoku(block_size_row, block_size_col, grid_size):
+def construct_sudoku(block_size_row=3, block_size_col=3, grid_size=9):
     """
     :return: a ProblemInstance object, along with a constraint-based oracle
     """

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -11,7 +11,7 @@ from sklearn.ensemble import RandomForestClassifier
 # Modify the problem generators for fast tests
 fast_problem_generators = [construct_murder_problem()]  # Keep only the smallest problem
 
-problem_generators = [construct_murder_problem(), construct_examtt_simple(6, 3, 2, 10), construct_nurse_rostering()]
+problem_generators = [construct_murder_problem(), construct_examtt_simple(), construct_nurse_rostering()]
 
 classifiers = [DecisionTreeClassifier(), RandomForestClassifier()]
 algorithms = [ca.QuAcq(), ca.MQuAcq(), ca.MQuAcq2(), ca.GQuAcq(), ca.PQuAcq()]


### PR DESCRIPTION
All benchmarks should have default values, but there were some without (e.g. sudoku). Now all of them have. 

Also, changed default values to smaller problems, for easier testing.