### PR TITLE
Metrics fix for short_dict

### DIFF
--- a/pycona/metrics.py
+++ b/pycona/metrics.py
@@ -252,7 +252,7 @@ class Metrics:
             results_df = pd.DataFrame([self.metrics_short_dict])
             print(results_df.to_string(index=False))
         except ImportError:
-            print(self.metrics_dict)
+            print(self.metrics_short_dict)
 
     @property
     def short_statistics(self):
@@ -264,7 +264,7 @@ class Metrics:
             results_df = pd.DataFrame([self.metrics_short_dict])
             return results_df
         except ImportError:
-            return self.metrics_dict
+            return self.metrics_short_dict
 
     def write_to_file(self, filename):
         """

--- a/pycona/metrics.py
+++ b/pycona/metrics.py
@@ -111,14 +111,14 @@ class Metrics:
         """
         self.total_size_queries += amount
 
-    def aggreagate_max_waiting_time(self, max2):
+    def aggreagate_max_waiting_time(self, t):
         """
         Aggregate the maximum waiting time.
 
-        :param max2: The new waiting time to compare with the current maximum.
+        :param t: The new waiting time to compare with the current maximum.
         """
-        if self.max_waiting_time < max2:
-            self.max_waiting_time = max2
+        if self.max_waiting_time < t:
+            self.max_waiting_time = t
 
     def increase_recommendation_queries_count(self, amount=1):
         """


### PR DESCRIPTION
There was a minor issue in short dict, when it was not possible to convert to dataframe, it would return the long dict instead of the short one.